### PR TITLE
Add bento-ctdc-static-content repo 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "crdc-ctdc-auth"]
 	path = crdc-ctdc-auth
 	url = https://github.com/CBIIT/crdc-ctdc-auth
+[submodule "bento-ctdc-static-content"]
+	path = bento-ctdc-static-content
+	url = https://github.com/CBIIT/bento-ctdc-static-content.git


### PR DESCRIPTION
- Adding [bento-ctdc-static-content](https://github.com/CBIIT/bento-ctdc-static-content) repo to [crdc-ctdc-starter-kit](https://github.com/CBIIT/crdc-ctdc-starter-kit)